### PR TITLE
chore: `__pycache__` removed from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 /uploads
 /.venv
 /.DS_Store
-/__pycache__/
+__pycache__/


### PR DESCRIPTION
(LIBE-5) – gitignore pycache